### PR TITLE
fix:ゲストユーザーのプライバシーポリシー閲覧設定

### DIFF
--- a/app/controllers/privacy_policies_controller.rb
+++ b/app/controllers/privacy_policies_controller.rb
@@ -1,3 +1,5 @@
 class PrivacyPoliciesController < ApplicationController
+  skip_before_action :check_guest_user
+
   def privacy_policy; end
 end


### PR DESCRIPTION
#### 修正点
- skip_before_action :check_guest_userをprivacy_policies_controllerに設定しゲストユーザーもプライバシーポリシーページを閲覧閲覧できるように修正