### PR TITLE
fix:モーダルウィンドウの表示を新規投稿時のみに限定

### DIFF
--- a/app/controllers/routes_controller.rb
+++ b/app/controllers/routes_controller.rb
@@ -25,7 +25,7 @@ class RoutesController < ApplicationController
     @route = current_user.routes.build(route_params)
 
     if @route.save
-      redirect_to route_path(@route), success: t("flash_messages.routes.create.success")
+      redirect_to route_path(@route), flash: { show_thanks_modal: true } # モーダル用のflash
     else
       flash.now[:danger] = t("flash_messages.routes.create.failure")
       render :new, status: :unprocessable_entity

--- a/app/views/routes/show.html.erb
+++ b/app/views/routes/show.html.erb
@@ -67,9 +67,9 @@
     </div>
   </div>
 
-  <!-- Modal -->
+  <!-- モーダルウィンドウ -->
   <div class="modal fade" id="thanksModal" tabindex="-1">
-    <div class="modal-dialog">
+    <div class="modal-dialog modal-dialog modal-dialog-centered">
       <div class="modal-content">
         <div class="modal-header">
           <h1 class="modal-title fs-5" id="thanksModalLabel">投稿ありがとうございます!</h1>
@@ -78,12 +78,16 @@
         <div class="modal-body">
           他にも知っているルートを共有しませんか？
         </div>
+
+        <div class="modal-footer">
+          <%= link_to "続けて投稿する", new_route_path, class: "btn btn-primary" %>
+        </div>
       </div>
     </div>
   </div>
 
   <!-- modal自動表示 -->
-  <% if flash[:success] %>
+  <% if flash[:show_thanks_modal] %>
     <script>
       (() => {
         // scriptが読み込まれた瞬間に実行される

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -6,6 +6,9 @@
       next
     end
   %>
+
+  <% next if message_type == "show_thanks_modal" %>
+
   <div class="alert <%= flash_bootstrap_class(message_type) %>">
     <%= message %>
   </div>


### PR DESCRIPTION
#### 変更点
- モーダルウィンドウでのサンクスメッセージの表示タイミング修正
- 投稿編集時にも表示されていたモーダルを新規投稿時のみに表示するよう設定
- モーダルウィンドウを出す代わりにroutes/show.html.erbではフラッシュメッセージを回避

#### 具体的なコード
```
# app/views/shared/_flash_messages.html.erbに以下を追加
<% next if message_type == "show_thanks_modal" %>
```

