### PR TITLE
fix:検索ウィンドウの表記を日本語に修正

### DIFF
--- a/app/javascript/controllers/slim_select_controller.js
+++ b/app/javascript/controllers/slim_select_controller.js
@@ -13,11 +13,14 @@ export default class extends Controller {
     // slim-select v2の初期化方法
     this.slimSelect = new SlimSelect({
       select: this.element,
-      placeholder: "タグを選択",
-      searchPlaceholder: "タグを検索",
-      searchText: "該当なし",
-      allowDeselect: true,
-      hideSelectedOption: true, // 追加: 選択済みオプションを隠す
+      settings: {  // ← settings オブジェクトで囲む
+        placeholderText: "タグを選択(複数選択可)",
+        searchPlaceholder: "タグを検索",
+        searchText: "該当なし", 
+        allowDeselect: true,
+        hideSelectedOption: true,
+        closeOnSelect: false,
+      }
     })
 
     // 初期化後に元のselectタグを強制的に非表示


### PR DESCRIPTION
#### やったこと

- [x] slim-selectで設定されていた英語表記を日本語に変更

#### リンク
- [(http://localhost:3000/stations/dc313bea-aca7-43a1-a8cf-ec8d80b898d7/routes)](http://localhost:3000/stations/dc313bea-aca7-43a1-a8cf-ec8d80b898d7/routes)