### PR TITLE
fix:port番号の変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,7 +86,7 @@ Rails.application.configure do
   # Gmail SMTP設定
   config.action_mailer.smtp_settings = {
     address: "smtp.gmail.com",
-    port: 587,
+    port: 465,
     domain: "gmail.com",
     user_name: ENV["GMAIL_USERNAME"],
     password: ENV["GMAIL_APP_PASSWORD"],


### PR DESCRIPTION
## 変更内容
- Gmail SMTPのポート番号を587から465に変更

## 変更理由
- メール送信エラーを解消するため